### PR TITLE
added the `EmptyCoordinator`

### DIFF
--- a/DemoFlowCoordinators/DemoFlowCoordinators/ContentCoordinatorView.swift
+++ b/DemoFlowCoordinators/DemoFlowCoordinators/ContentCoordinatorView.swift
@@ -13,32 +13,36 @@ struct ContentCoordinatorView: View {
     
     var body: some View {
         FlowCoordinatorView(coordinator) {
-            ContentView(vm: coordinator.vm)
-#if !os(macOS)
-                .fullScreenCover(item: $coordinator.coverType, content: { (item) in
-                    SheetView(title: "Cover View")
-                })
-#endif
-                .sheet(item: $coordinator.sheetType) { (item) in
-                    switch item {
-                    case .sheetFirst(let title):
-                        SheetView(title: title)
-                    }
-                }
-                .navigationDestination(for: ContentViewModel.LinkType.self) { (item) in
-                    switch item {
-                    case .linkFirstWithParams(let title),
-                            .linkThirdWithParams(let title):
-                        NavigationLinkView(title: title)
-                    case .linkSecond:
-                        NavigationLinkView(title: "Test Second Link")
-                    case .linkSecondCoordinator:
-                        SecondContentCoordinatorView(coordinator: coordinator.secondContentCoordinator)
-                    case .linkSecondCoordinator2:
-                        SecondContentCoordinatorView(coordinator: coordinator.secondContentCoordinator)
-                    }
-                }
+            bodyView
         }
+    }
+    
+    private var bodyView: some View {
+        ContentView(vm: coordinator.vm)
+#if !os(macOS)
+            .fullScreenCover(item: $coordinator.coverType, content: { (item) in
+                SheetView(title: "Cover View")
+            })
+#endif
+            .sheet(item: $coordinator.sheetType) { (item) in
+                switch item {
+                case .sheetFirst(let title):
+                    SheetView(title: title)
+                }
+            }
+            .navigationDestination(for: ContentViewModel.LinkType.self) { (item) in
+                switch item {
+                case .linkFirstWithParams(let title),
+                        .linkThirdWithParams(let title):
+                    NavigationLinkView(title: title)
+                case .linkSecond:
+                    NavigationLinkView(title: "Test Second Link")
+                case .linkSecondCoordinator:
+                    SecondContentCoordinatorView(coordinator: coordinator.secondContentCoordinator)
+                case .linkSecondCoordinator2:
+                    SecondContentCoordinatorView(coordinator: coordinator.secondContentCoordinator)
+                }
+            }
     }
     
 }

--- a/DemoFlowCoordinators/DemoFlowCoordinators/SecondContentViewModel.swift
+++ b/DemoFlowCoordinators/DemoFlowCoordinators/SecondContentViewModel.swift
@@ -13,7 +13,7 @@ final class SecondContentCoordinator: SheetAndLinkCoordinator<SecondContentViewM
     @Published var vm: SecondContentViewModel!
         
     init(parentCoordinator: ContentCoordinator? = nil, title: String) {
-        super.init(parentFlowCoordinator: parentCoordinator)
+        super.init(parent: parentCoordinator)
         vm = SecondContentViewModel(coordinator: self, title: title)
     }
 }

--- a/Sources/KVKFlowCoordinators/KVKFlowCoordinatorView.swift
+++ b/Sources/KVKFlowCoordinators/KVKFlowCoordinatorView.swift
@@ -23,7 +23,7 @@ public struct FlowCoordinatorView<T: FlowProtocol, U: View>: View {
     
     public var body: some View {
         // if parent coordinator has already containts `NavigationStack` no need to add the another one
-        if let parent = coordinator.parentFlowCoordinator, parent.canWorkWithLink {
+        if let parent = coordinator.parent, parent.canWorkWithLink {
             content()
         } else if coordinator.canWorkWithLink || useNavigationStack {
             NavigationStack(path: $coordinator.path) {


### PR DESCRIPTION
- rename parent property
- move functions inside the base class